### PR TITLE
Make the server_name configurable with a sane default

### DIFF
--- a/config.php
+++ b/config.php
@@ -14,4 +14,5 @@ $config['ttl_max']  = 3600*24*30;       // maximum ttl is 30 days
 
 $config['paste_max_chars'] = 1024*300;        // size limit in characters
 
+$config['server_name'] = 'https://p.6core.net/'; // server url
 

--- a/tpl/form.php
+++ b/tpl/form.php
@@ -18,6 +18,6 @@
 	<input value="Save" type="submit"/>
 	<div class="text">
 	Hint: put the following oneliner in your .bashrc to use "6p &lt;file&gt;" or "echo hi | 6p" (thanks, Habbie and Reinhart):<br><br>
-	<code>6p() { curl -s -F "content=<${1--}" -F ttl=604800 -w "%{redirect_url}\n" -o /dev/null https://p.6core.net/; }</code>
+	<code>6p() { curl -s -F "content=<${1--}" -F ttl=604800 -w "%{redirect_url}\n" -o /dev/null <?=$config['server_name']?> }</code>
 	</div>
 </form>

--- a/webroot/index.php
+++ b/webroot/index.php
@@ -69,6 +69,12 @@ function check_setup()
 		die('You should allow less pastes per hour than per day, silly');
 	}
 
+	// 
+	if( empty($config['server_name']) )
+	{
+		$config['server_name'] = 'https://p.6core.net';
+	}
+
 	// htaccess installed?
 	if( !file_exists('.htaccess'))
 	{


### PR DESCRIPTION
Did some modifications to allow setting a custom server name, it makes easier to crete the shell shortcut.
