### PR TITLE
Update nginx documentation to avoid Pitfalls

### DIFF
--- a/server-conf/README.md
+++ b/server-conf/README.md
@@ -14,7 +14,7 @@ NGINX INSTALL
 
 - Add the server configuration example that you find at 'nginx/nginx-conf.txt' to your NGINX configuration file.
 
-- Copy the 'nginx/index.php' to the 'webroot/' directory of your 6paster installation.
+- Copy the 'webroot/index.php' to the 'webroot/' directory of your 6paster installation.
 
 - Reload the NGINX process.
 

--- a/server-conf/nginx-conf.txt
+++ b/server-conf/nginx-conf.txt
@@ -6,8 +6,9 @@ server {
         listen        80;
         server_name   <your.server.name>;
 
+        root <www-document-root>/webroot;
+
         location / {
-                root <www-document-root>/webroot;
                 index index.html index.htm index.php;
         }
 


### PR DESCRIPTION
Updating NGINX documentation, root in location block would not work for me, moving it outside worked right away. Found solution on http://wiki.nginx.org/Pitfalls
