### PR TITLE
add missing ; which caused bash to expect input

### DIFF
--- a/tpl/form.php
+++ b/tpl/form.php
@@ -18,6 +18,6 @@
 	<input value="Save" type="submit"/>
 	<div class="text">
 	Hint: put the following oneliner in your .bashrc to use "6p &lt;file&gt;" or "echo hi | 6p" or "cat << EOF | 6p" (thanks, Habbie and Reinhart):<br><br>
-	<code>6p() { curl -s -F "content=<${1--}" -F ttl=604800 -w "%{redirect_url}\n" -o /dev/null <?=htmlspecialchars($config['server_name'])?> }</code>
+	<code>6p() { curl -s -F "content=<${1--}" -F ttl=604800 -w "%{redirect_url}\n" -o /dev/null <?=htmlspecialchars($config['server_name'])?>; }</code>
 	</div>
 </form>


### PR DESCRIPTION
fixed bug which caused the ; to be missing after the URL, version running @ p.6core.net has the ; present
