### PR TITLE
Minor cleanup to allow use with PHP 8.0

### DIFF
--- a/webroot/index.php
+++ b/webroot/index.php
@@ -43,12 +43,6 @@ function check_setup()
 {
 	global $config;
 
-	// check register_globals
-	if( ini_get('register_globals') )
-	{
-		die('register_globals is enabled. I can\'t work like this.');
-	}
-
 	// check SSL
 	if( !array_key_exists('HTTPS', $_SERVER) || $_SERVER['HTTPS'] != "on")
 	{

--- a/webroot/index.php
+++ b/webroot/index.php
@@ -49,12 +49,6 @@ function check_setup()
 		die('register_globals is enabled. I can\'t work like this.');
 	}
 
-	// check gpc_quotes
-	if( get_magic_quotes_gpc() )
-	{
-		die('magic_quotes_gpc is enabled. I can\'t work like this.');
-	}
-
 	// check SSL
 	if( !array_key_exists('HTTPS', $_SERVER) || $_SERVER['HTTPS'] != "on")
 	{


### PR DESCRIPTION
Trivial changes, but these let the paster work for me under PHP 8.0.
Since the checks involve features removed per PHP 5.4, this shouldn't harm anyone.

After all, PHP 5.4 went EOL in Sept. 2015.